### PR TITLE
Update MEM_AP_WriteValueRepeat for uint64 val

### DIFF
--- a/rddi-memap_cswp/env.cpp
+++ b/rddi-memap_cswp/env.cpp
@@ -49,7 +49,7 @@ public:
     virtual void MEM_AP_ReadRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, void* buf) = 0;
     virtual void MEM_AP_Write(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned size, const void* buf) = 0;
     virtual void MEM_AP_WriteRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, const void* buf) = 0;
-    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val) = 0;
+    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val) = 0;
     virtual void MEM_AP_Fill(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 pattern) = 0;
     virtual void MEM_AP_AccessBatch(int apNumber, uint64 baseAddress, MEM_AP_OP* ops, unsigned numOps, unsigned* opsCompleted) = 0;
 };
@@ -119,7 +119,7 @@ public:
         Fail();
     }
 
-    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val)
+    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val)
     {
         Fail();
     }
@@ -177,7 +177,7 @@ public:
     virtual void MEM_AP_ReadRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, void* buf);
     virtual void MEM_AP_Write(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned size, const void* buf);
     virtual void MEM_AP_WriteRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, const void* buf);
-    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val);
+    virtual void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val);
     virtual void MEM_AP_Fill(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 pattern);
     virtual void MEM_AP_AccessBatch(int apNumber, uint64 baseAddress, MEM_AP_OP* ops, unsigned numOps, unsigned* opsCompleted);
 private:
@@ -524,7 +524,7 @@ void MemAPImpl::doWrite(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsi
         throw RddiEx(RDDI_FAILED, "CSWP memory write failed");
 }
 
-void MemAPImpl::MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val)
+void MemAPImpl::MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val)
 {
     if (!m_connected)
         throw RddiEx(RDDI_NOCONN, "MEM-AP interface not connected");
@@ -549,7 +549,7 @@ void MemAPImpl::MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SI
         break;
 
     case MEM_AP_ACC_32:
-        repVal = val;
+        repVal = static_cast<uint32>(val);
         bufSz = repeatCount;
         writeSize = repeatCount * 4;
         break;
@@ -586,7 +586,7 @@ void MemAPImpl::MEM_AP_Fill(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, 
         break;
 
     case MEM_AP_ACC_32:
-        repVal = pattern;
+        repVal = static_cast<uint32>(pattern);
         break;
 
     default:
@@ -839,7 +839,7 @@ void Env::MEM_AP_WriteRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize,
     m_impl->MEM_AP_WriteRepeat(apNumber, addr, accSize, flags, repeatCount, buf);
 }
 
-void Env::MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val)
+void Env::MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val)
 {
     m_impl->MEM_AP_WriteValueRepeat(apNumber, addr, accSize, flags, repeatCount, val);
 }

--- a/rddi-memap_cswp/env.h
+++ b/rddi-memap_cswp/env.h
@@ -43,7 +43,7 @@ public:
     void MEM_AP_ReadRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, void* buf);
     void MEM_AP_Write(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned size, const void* buf);
     void MEM_AP_WriteRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, const void* buf);
-    void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val);
+    void MEM_AP_WriteValueRepeat(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val);
     void MEM_AP_Fill(int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 pattern);
     void MEM_AP_AccessBatch(int apNumber, uint64 baseAddress, MEM_AP_OP* ops, unsigned numOps, unsigned* opsCompleted);
 

--- a/rddi-memap_cswp/rddi_stubs.cpp
+++ b/rddi-memap_cswp/rddi_stubs.cpp
@@ -186,7 +186,7 @@ RDDI int MEM_AP_WriteRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP
     return LastErrorCode();
 }
 
-RDDI int MEM_AP_WriteValueRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val)
+RDDI int MEM_AP_WriteValueRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val)
 {
     TRAP_EXCEPTIONS(EnvironmentMap::Lookup(handle)->MEM_AP_WriteValueRepeat(apNumber, addr, accSize, flags, repeatCount, val));
     return LastErrorCode();

--- a/rddi/rddi_mem_ap.h
+++ b/rddi/rddi_mem_ap.h
@@ -357,7 +357,7 @@ RDDI int MEM_AP_WriteRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP
  * @param[out] val The value to write
  * @return RDDI_SUCCESS on success, otherwise RDDI_xxxx on error
  */
-RDDI int MEM_AP_WriteValueRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint32 val);
+RDDI int MEM_AP_WriteValueRepeat(RDDIHandle handle, int apNumber, uint64 addr, MEM_AP_ACC_SIZE accSize, unsigned flags, unsigned repeatCount, uint64 val);
 
 /**
  * Fill a block of memory on a MEM-AP


### PR DESCRIPTION
The rddi_mem_ap.h MEM_AP_WriteValueRepeat function is being fixed to allow a uint64 val given that MEM_AP_ACC_SIZE accSize could be AP_64BIT. Currently this implementation does not support AP_64BIT, so val is cast back to uint32. Future work could enable AP_64BIT if needed.