### PR TITLE
Updated for Visual Studio 2022 and enabled full cswp_server logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ The script uses *cmake* to create *Makefiles*, then run *make* to build the bina
 
 #### Requirements
 
-* Visual Studio 2015
-* [Windows Driver Kit 10 for Visual Studio 2015](https://docs.microsoft.com/en-us/windows-hardware/drivers/other-wdk-downloads)
+* Visual Studio 2022
+* [Windows Driver Kit 10 for Visual Studio 2022](https://docs.microsoft.com/en-us/windows-hardware/drivers/other-wdk-downloads)
 * [Boost 1.64](https://www.boost.org/users/history/) ([prebuilt Windows](https://sourceforge.net/projects/boost/files/boost-binaries/) binaries are available)
 * [cmake 3.8 or later](https://cmake.org/download/)
 * [fff 1.0](https://github.com/meekrosoft/fff) (used for tests, downloaded automatically from GitHub during build)
@@ -90,7 +90,7 @@ The script uses *cmake* to create *Makefiles*, then run *make* to build the bina
 
 Boost 1.64 is required. Set the BOOST_ROOT environment variable to point to Boost installation location. If a non-standard Boost directory structure is used, then set BOOST_INCLUDEDIR and BOOST_LIBRARYDIR to point to the *include* and *library* directories respectively.
 
-Open a command prompt (e.g. Visual studio 2015 command prompt) in this directory. PATH must contain cmake and visual studio. Run:
+Open a command prompt (e.g. Visual studio 2022 command prompt) in this directory. PATH must contain cmake and visual studio. Run:
 `build.bat Debug`
 
 This generates Visual Studio projects. Open in Visual Studio and build the INSTALL target. This copies the binaries and necessary files to run the tools to:

--- a/build.bat
+++ b/build.bat
@@ -9,7 +9,7 @@ if "%REGIME%" == "" (
 
 set SRC_DIR=..\..\..
 set BUILD_DIR=build\win_32-x86_64\%REGIME%
-set GEN="Visual Studio 14 2015 Win64"
+set GEN="Visual Studio 17 2022"
 
 mkdir build
 mkdir build\win_32-x86_64

--- a/target/cswp_server/cswp_server.c
+++ b/target/cswp_server/cswp_server.c
@@ -543,7 +543,7 @@ int main(int argc, char **argv)
     const char* logFile = 0;
     const char* transport = "";
 
-    int verbose = 0;
+    int verbose = 3;
 
     if (argc > 1)
         chdir(argv[1]);

--- a/tcp_client/tests/CMakeLists.txt
+++ b/tcp_client/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(tcp_client_test
   )
 
 FILE (DOWNLOAD "https://raw.githubusercontent.com/meekrosoft/fff/v1.0/fff.h" "${CMAKE_CURRENT_SOURCE_DIR}/fff.h")
-FILE (DOWNLOAD "https://raw.githubusercontent.com/onqtam/doctest/2.3.5/doctest/doctest.h" "${CMAKE_CURRENT_SOURCE_DIR}/doctest.h")
+FILE (DOWNLOAD "https://raw.githubusercontent.com/doctest/doctest/v2.4.11/doctest/doctest.h" "${CMAKE_CURRENT_SOURCE_DIR}/doctest.h")
 
 target_link_libraries(tcp_client_test PRIVATE tcp_client)
 


### PR DESCRIPTION
Build.bat script updated with information to run with Visual Studio 2022. Doctest url updated to a newer version in tcp_client/tests/CmakeLists.txt. Full logging of cswp_server enabled by default by changing verbose variable to 3 in cswp_server.c. README.md updated to state Visual Studio 2022 rather than Visual Studio 2015.